### PR TITLE
Add support for IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Optional:
 
 * schema=`default schema`
 * timezone=`default timezone`
+* preferred_address_family=`ipv6`
 
 ## Test
 

--- a/cnuodb.cpp
+++ b/cnuodb.cpp
@@ -53,7 +53,13 @@ int nuodb_open(struct nuodb *db, const char *database, const char *username,
             const char *k = props[i];
             const char *v = props[i+1];
             if (k && v && std::strlen(k) > 0 && std::strlen(v) > 0) {
-                p->putValue(k, v);
+                if (std::strcmp(k, "preferred_address_family") == 0) {
+                    if (std::strcmp(v, "ipv6") == 0) {
+                        p->putValue("ipVersion", "v6");
+                    }
+                } else {
+                    p->putValue(k, v);
+                }
             }
         }
 

--- a/cnuodb.h
+++ b/cnuodb.h
@@ -19,6 +19,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <stddef.h>
 
 struct nuodb;
 struct nuodb_statement;


### PR DESCRIPTION
Support IPv6 with new query preferred_address_family=ipv6 that will cause ipVersion=v6 property to be sent into the underlying CPP driver code. Tested with nuodb ipv6-docker test code against nuodb software containing IPv6 support.